### PR TITLE
Removing #13 as a chord extension because it's invalid/redundant.

### DIFF
--- a/about.php
+++ b/about.php
@@ -33,7 +33,7 @@
                     <li>Intermediate: maj7, 6, m6, sus2, sus4, 9, m9</li>
                     <li>Advanced: +, °, m7♭5, 7alt, 6/9, 11, 13</li>
                 </ol>
-                You can also specify if you want additional extensions (♯5, ♭5, ♯9, ♭9, ♯11, ♯13, ♭13) added to the chords by checking the <em>Add extensions</em> checkbox.<br />If you really want to kick it up a notch, check the <em>Hide next chord</em> checkbox to get the next chord without any warning!
+                You can also specify if you want additional extensions (♯5, ♭5, ♯9, ♭9, ♯11, ♭13) added to the chords by checking the <em>Add extensions</em> checkbox.<br />If you really want to kick it up a notch, check the <em>Hide next chord</em> checkbox to get the next chord without any warning!
             </li>
         </ol>
         <div class="row bg-light mb-2">

--- a/data/data.js
+++ b/data/data.js
@@ -7,7 +7,7 @@ var $augmented_chords = ["+", "7alt"];
 var $dominant_chords = ["7", "9", "11", "13"];
 var $all_chords = [].concat($major_chords, $minor_chords, $diminished_chords, $augmented_chords, $dominant_chords);
 
-var $extension = ["", "(♯5)", "(♭5)", "(♯9)", "(♭9)", "(♯11)", "(♯13)", "(♭13)"];
+var $extension = ["", "(♯5)", "(♭5)", "(♯9)", "(♭9)", "(♯11)", "(♭13)"];
 
 var $keys = {
     "G♭ Major":   ["G♯", "A♭", "B♭", "C♭", "D♭", "E♭", "F"],

--- a/index.php
+++ b/index.php
@@ -179,7 +179,7 @@
                     <div class="col">
                         <div class="custom-control custom-checkbox mt-3">
                             <input type="checkbox" class="custom-control-input" id="extensions" name="extensions" />
-                            <label for="extensions" class="custom-control-label">Add extensions <small>(♯5, ♭5, ♯9, ♭9, ♯11, ♯13, ♭13)</small></label>
+                            <label for="extensions" class="custom-control-label">Add extensions <small>(♯5, ♭5, ♯9, ♭9, ♯11, ♭13)</small></label>
                         </div>
                         <div class="custom-control custom-checkbox mt-3">
                             <input type="checkbox" class="custom-control-input" id="rare_enharmonics" name="rare_enharmonics" />


### PR DESCRIPTION
Resolves #53 by removing `#13` as a possible chord extension.