### PR TITLE
107 bug gb major scale has a g instead of gb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Current versions:
 
 ---
 
+## Release 1.10
+
+Date: May 25, 2025
+URL: <https://github.com/KCarlile/flashchord/releases/tag/v1.10>  
+Commit: (COMMIT URL)
+
+- Fixed G# in Gb key. (Issue [#107](https://github.com/KCarlile/flashchord/issues/107))
+
 ## Release 1.9
 
 Tag: v1.9  
@@ -21,6 +29,7 @@ Commit: <https://github.com/KCarlile/flashchord/commit/6381b4cb17e04d9c038ec053d
 - Added Contributors to About page.
 - Added Supporters to Donate page.
 - Minor UI/UX tweaks.
+- Fixed G# in Gb key.
 
 ## Release 1.8
 

--- a/data/data.js
+++ b/data/data.js
@@ -10,7 +10,7 @@ var $all_chords = [].concat($major_chords, $minor_chords, $diminished_chords, $a
 var $extensions = ["", "(♯5)", "(♭5)", "(♯9)", "(♭9)", "(♯11)", "(♭13)"];
 
 var $keys = {
-    "G♭ Major":   ["G♯", "A♭", "B♭", "C♭", "D♭", "E♭", "F"],
+    "G♭ Major":   ["G♭", "A♭", "B♭", "C♭", "D♭", "E♭", "F"],
     "D♭ Major":   ["D♭", "E♭", "F", "G♭", "A♭", "B♭", "C"],
     "A♭ Major":   ["A♭", "B♭", "C", "D♭", "E♭", "F", "G"],
     "E♭ Major":   ["E♭", "F", "G", "A♭", "B♭", "C", "D"],


### PR DESCRIPTION
From #107, fixed the typo from G# to Gb